### PR TITLE
Style fixes

### DIFF
--- a/src/news-app.html
+++ b/src/news-app.html
@@ -226,12 +226,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           will-change: opacity;
         }
 
-        .expanded-header[shown] {
+        news-sticky-header[shown] .expanded-header[shown] {
           transform: translate3d(0, 100%, 0);
         }
 
-        .expanded-header[shown] > div {
+        news-sticky-header[shown] .expanded-header[shown] > div {
           opacity: 1;
+        }
+
+        .toggle-drawer-btn {
+          display: none;
         }
       }
 
@@ -276,7 +280,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <header id="header" role="navigation">
       <app-toolbar class="logo-toolbar">
-        <paper-icon-button icon="menu" on-click="_toggleDrawer"></paper-icon-button>
+        <paper-icon-button class="toggle-drawer-btn" icon="menu" on-click="_toggleDrawer"></paper-icon-button>
         <div class="logo" main-title><a href="/" aria-label="NEWS Home">NEWS</a></div>
         <paper-icon-button icon="search"></paper-icon-button>
       </app-toolbar>
@@ -309,11 +313,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
       <div class="expanded-header" shown$="[[drawerOpened]]">
         <div>
-        <iron-selector role="navigation" selected="[[categoryName]]" attr-for-selected="name">
-          <template is="dom-repeat" items="[[categories]]" as="category" initial-count="4">
-            <a name="[[category.name]]" href="/list/[[category.name]]">[[category.title]]</a>
-          </template>
-        </iron-selector>
+          <iron-selector role="navigation" selected="[[categoryName]]" attr-for-selected="name">
+            <template is="dom-repeat" items="[[categories]]" as="category" initial-count="4">
+              <a name="[[category.name]]" href="/list/[[category.name]]">[[category.title]]</a>
+            </template>
+          </iron-selector>
         </div>
       </div>
     </news-sticky-header>

--- a/src/news-list-item.html
+++ b/src/news-list-item.html
@@ -210,6 +210,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           margin-top: 20px;
         }
 
+        :host(:not([featured])) .img-container > img {
+          height: 150px;
+        }
+
       }
 
     </style>

--- a/src/news-sticky-header.html
+++ b/src/news-sticky-header.html
@@ -31,18 +31,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         visibility: hidden;
         pointer-events: none;
         transition: transform 0.3s ease-in-out, visibility 0.3s ease-in-out;
-        transform: translate3d(0, -64px, 0);
+        transform: translate3d(0, -100%, 0);
       }
 
-      :host([visible]) {
+      :host([shown]) {
         visibility: visible;
         pointer-events: auto;
         transform: translate3d(0, 0, 0);
       }
 
     </style>
-
-    <iron-media-query query="max-width: 767px" query-matches="{{smallScreen}}"></iron-media-query>
 
     <content></content>
 
@@ -53,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       is: 'news-sticky-header',
 
       properties: {
-        visible: {
+        shown: {
           type: Boolean,
           reflectToAttribute: true
         }
@@ -74,7 +72,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _scrollHandler: function() {
         var scrollTop = window.pageYOffset;
-        this.visible = (scrollTop >= this.threshold);
+        this.shown = (scrollTop >= this.threshold);
       }
 
 


### PR DESCRIPTION
- Hide the toggle menu on desktop
- Remove unnecessary iron-media-query from news-sticky-header.
- Fix image size for the list items on desktop.
