### PR TITLE
Remove share links from the article body when it's on mobile

### DIFF
--- a/src/news-article.html
+++ b/src/news-article.html
@@ -198,6 +198,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           width: auto;
           padding: 0 24px;
         }
+
+        .share-link {
+          display: none;
+        }
       }
 
       @media (max-width: 1309px) {


### PR DESCRIPTION
The links (email & share) are already there on the toolbar.
