### PR TITLE
Reduce jank when in the nav on desktop

### DIFF
--- a/src/news-header.html
+++ b/src/news-header.html
@@ -114,9 +114,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         color: inherit;
         text-decoration: none;
         margin: 0 10px;
+        letter-spacing: 0.08em;
       }
 
       .menu-list a.iron-selected {
+        letter-spacing: 0em;
         font-weight: bold;
       }
 


### PR DESCRIPTION
Tried this fix, and it does reduce the jank although it's not 100%. However, it's much simpler than the `::after` hack.