### PR TITLE
set open graph/twitter card metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components/
+node_modules/
 build/
 *.pyc

--- a/src/news-app.html
+++ b/src/news-app.html
@@ -315,6 +315,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Response by a11y announcing the section and syncronizing the category.
       _updateDocumentTitle(page, categoryTitle, articleHeadline, appTitle) {
         document.title = (page === 'list' ? categoryTitle : articleHeadline) + ' - ' + appTitle;
+        this._setPageMetadata(articleHeadline);
+      }
+
+      _setPageMetadata(description) {
+        let image = this.articleId ? `/images/${this.articleId}.jpg` : 'images/news-icon-128.png';
+        // Set open graph metadata
+        this._setMeta('property', 'og:title', document.title);
+        this._setMeta('property', 'og:description', description || document.title);
+        this._setMeta('property', 'og:url', document.location.href);
+        this._setMeta('property', 'og:image', this.baseURI + image);
+
+        // Set twitter card metadata
+        this._setMeta('property', 'twitter:title', document.title);
+        this._setMeta('property', 'twitter:description', description || document.title);
+        this._setMeta('property', 'twitter:url', document.location.href);
+        this._setMeta('property', 'twitter:image:src', this.baseURI + image);
+      }
+
+      _setMeta(attrName, attrValue, content) {
+        let element = document.head.querySelector(`meta[${attrName}="${attrValue}"]`);
+        if (!element) {
+          element = document.createElement('meta');
+          element.setAttribute(attrName, attrValue);
+          document.head.appendChild(element);
+        }
+        element.setAttribute('content', content || '');
       }
 
       _refreshData() {

--- a/src/news-app.html
+++ b/src/news-app.html
@@ -315,11 +315,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Response by a11y announcing the section and syncronizing the category.
       _updateDocumentTitle(page, categoryTitle, articleHeadline, appTitle) {
         document.title = (page === 'list' ? categoryTitle : articleHeadline) + ' - ' + appTitle;
-        this._setPageMetadata(articleHeadline);
+        if (page === 'list') {
+          this._setPageMetadata(categoryTitle, null);
+        } else {
+          this._setPageMetadata(articleHeadline, this.articleId);
+        }
       }
 
-      _setPageMetadata(description) {
-        let image = this.articleId ? `/images/${this.articleId}.jpg` : 'images/news-icon-128.png';
+      _setPageMetadata(description, articleId) {
+        let image = articleId ? `/images/${articleId}.jpg` : 'images/news-icon-128.png';
+
         // Set open graph metadata
         this._setMeta('property', 'og:title', document.title);
         this._setMeta('property', 'og:description', description || document.title);


### PR DESCRIPTION
For a list (the Chrome category):
<img width="574" alt="screen shot 2017-10-09 at 2 39 55 pm" src="https://user-images.githubusercontent.com/1369170/31359661-c4edb818-acff-11e7-9205-1e6ba10808c9.png">

For an article in that list:
<img width="577" alt="screen shot 2017-10-09 at 2 40 06 pm" src="https://user-images.githubusercontent.com/1369170/31359665-c71ba67c-acff-11e7-92f0-5a0d3c2b37f6.png">
